### PR TITLE
Refactor GetById to return single UserModel

### DIFF
--- a/MRMDataManager/Controllers/UserController.cs
+++ b/MRMDataManager/Controllers/UserController.cs
@@ -12,12 +12,12 @@ namespace MRMDataManager.Controllers
     [Authorize]
     public class UserController : ApiController
     {
-        public List<UserModel> GetById()
+        public UserModel GetById()
         {
             string userId = RequestContext.Principal.Identity.GetUserId();
             UserData data = new UserData();
 
-            return data.GetUserById(userId);
+            return data.GetUserById(userId).First();
         }
     }
 }


### PR DESCRIPTION
Refactored the `GetById` method in the `UserController` class to change its return type from `List<UserModel>` to `UserModel`, ensuring it now returns a single `UserModel` object instead of a list. Modified the data retrieval within `GetById` to return the first user by appending `.First()` to the data fetching method, aligning with the updated return type.