### PR TITLE
Add SalesView and ViewModel for sales feature

### DIFF
--- a/MRMDesktopUI/MRMDesktopUI.csproj
+++ b/MRMDesktopUI/MRMDesktopUI.csproj
@@ -102,9 +102,13 @@
     <Compile Include="Bootstrapper.cs" />
     <Compile Include="Helpers\PasswordBoxHelper.cs" />
     <Compile Include="ViewModels\LoginViewModel.cs" />
+    <Compile Include="ViewModels\SalesViewModel.cs" />
     <Compile Include="ViewModels\ShellViewModel.cs" />
     <Compile Include="Views\LoginView.xaml.cs">
       <DependentUpon>LoginView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SalesView.xaml.cs">
+      <DependentUpon>SalesView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\ShellView.xaml.cs">
       <DependentUpon>ShellView.xaml</DependentUpon>
@@ -114,6 +118,10 @@
       <SubType>Code</SubType>
     </Compile>
     <Page Include="Views\LoginView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\SalesView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -1,0 +1,13 @@
+﻿using Caliburn.Micro;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MRMDesktopUI.ViewModels
+{
+    public class SalesViewModel : Screen
+    {
+    }
+}

--- a/MRMDesktopUI/Views/SalesView.xaml
+++ b/MRMDesktopUI/Views/SalesView.xaml
@@ -1,0 +1,21 @@
+﻿<UserControl x:Class="MRMDesktopUI.Views.SalesView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:MRMDesktopUI.Views"
+             mc:Ignorable="d" Background="White" FontSize="24"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+    </Grid>
+</UserControl>

--- a/MRMDesktopUI/Views/SalesView.xaml.cs
+++ b/MRMDesktopUI/Views/SalesView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace MRMDesktopUI.Views
+{
+    /// <summary>
+    /// Interaction logic for SalesView.xaml
+    /// </summary>
+    public partial class SalesView : UserControl
+    {
+        public SalesView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new feature focused on sales data management and display within the application. Key changes include:

- Added `SalesViewModel.cs` in the `ViewModels` folder, implementing the `Caliburn.Micro.Screen` for MVVM architecture support, indicating the setup for handling sales-related logic.
- Introduced `SalesView.xaml` and `SalesView.xaml.cs` under the `Views` folder, establishing the UI layout and its code-behind. This includes setting up the UserControl with a white background, a font size of 24, and a grid layout for dynamic content display.
- Configured `SalesView.xaml.cs` as dependent on `SalesView.xaml` and included `SalesView.xaml` as a Page item in the `MRMDesktopUI.csproj` project file, ensuring proper compilation and designer tool support in Visual Studio.

These additions are structured to enhance the application's functionality by providing a dedicated interface and logic for sales data interaction, adhering to the MVVM design pattern for clear separation of concerns.