### PR TITLE
Refactor ItemQuantity in SalesViewModel

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -35,15 +35,15 @@ namespace MRMDesktopUI.ViewModels
         }
 
 
-        private string _itemQuantity;
+        private int _itemQuantity;
 
-        public string ItemQuantity
+        public int ItemQuantity
         {
             get { return _itemQuantity; }
             set
             {
                 _itemQuantity = value;
-                NotifyOfPropertyChange(() => Products);
+                NotifyOfPropertyChange(() => ItemQuantity);
             }
         }
 


### PR DESCRIPTION
- Changed the type of `ItemQuantity` from `string` to `int` in `SalesViewModel`, aligning the backing field `_itemQuantity` with the new type.
- Updated the `ItemQuantity` property setter to correctly notify changes to `ItemQuantity` instead of `Products`, ensuring accurate UI updates.