### PR TITLE
Enhance ShellViewModel with SalesViewModel

### DIFF
--- a/MRMDesktopUI/ViewModels/ShellViewModel.cs
+++ b/MRMDesktopUI/ViewModels/ShellViewModel.cs
@@ -13,17 +13,21 @@ namespace MRMDesktopUI.ViewModels
     {
         private LoginViewModel _loginVM;
         private IEventAggregator _events;
-        public ShellViewModel(LoginViewModel loginVM, IEventAggregator events)
+        private SalesViewModel _salesVM;
+        public ShellViewModel(LoginViewModel loginVM, IEventAggregator events, SalesViewModel salesVM)
         {
             _events = events;
-            _events.Subscribe(this);
             _loginVM = loginVM;
+            _salesVM = salesVM;
+
+            _events.Subscribe(this);
+
             ActivateItem(_loginVM);
         }
 
         public void Handle(LogOnEvent message)
         {
-            throw new NotImplementedException();
+            ActivateItem(_salesVM);
         }
     }
 }


### PR DESCRIPTION
- Modified ShellViewModel constructor to accept a SalesViewModel parameter, enabling a direct reference.
- Added a private SalesViewModel field (_salesVM) to store the passed SalesViewModel instance.
- Moved the event aggregator subscription (_events.Subscribe(this)) to after _salesVM initialization, ensuring proper field setup before event listening.
- Updated the Handle method to activate the SalesViewModel (_salesVM) on LogOnEvent, replacing the previous NotImplementedException with functionality to display the sales view.