### PR TITLE
Add ItemTemplate to Products ListBox

### DIFF
--- a/MRMDesktopUI/Views/SalesView.xaml
+++ b/MRMDesktopUI/Views/SalesView.xaml
@@ -33,7 +33,13 @@
         <!-- Column 0 -->
         <TextBlock Text="Items" Grid.Row="1" Grid.Column="0" Grid.RowSpan="2"/>
         <ListBox x:Name="Products" Grid.Row="2" Grid.Column="0"
-                 MinHeight="200" MinWidth="150"/>
+                 MinHeight="200" MinWidth="150">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding ProductName}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
 
         <!-- Column 1 -->
         <StackPanel Orientation="Vertical" Grid.Column="1"


### PR DESCRIPTION
Enhanced the `Products` ListBox in `SalesView.xaml` by incorporating an `ItemTemplate` that utilizes a `TextBlock` for displaying the `ProductName` property of each item. This modification significantly improves item presentation compared to the previous version, which only defined minimum dimensions without specifying how items should be displayed.