### PR TITLE
Add SelectedProduct binding to SalesView

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -43,6 +43,19 @@ namespace MRMDesktopUI.ViewModels
             }
         }
 
+        private ProductModel _selectedProduct;
+
+        public ProductModel SelectedProduct
+        {
+            get { return _selectedProduct; }
+            set
+            {
+                _selectedProduct = value;
+                NotifyOfPropertyChange(() => SelectedProduct);
+            }
+        }
+
+
         private BindingList<ProductModel> _cart;
 
         public BindingList<ProductModel> Cart

--- a/MRMDesktopUI/Views/SalesView.xaml
+++ b/MRMDesktopUI/Views/SalesView.xaml
@@ -33,7 +33,7 @@
         <!-- Column 0 -->
         <TextBlock Text="Items" Grid.Row="1" Grid.Column="0" Grid.RowSpan="2"/>
         <ListBox x:Name="Products" Grid.Row="2" Grid.Column="0"
-                 MinHeight="200" MinWidth="150">
+                 MinHeight="200" MinWidth="150" SelectedItem="{Binding SelectedProduct}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding ProductName}"/>


### PR DESCRIPTION
- Introduced a new `SelectedProduct` property in `SalesViewModel.cs` to track the currently selected product in the UI. This includes a private `_selectedProduct` field and a public getter/setter that triggers `NotifyOfPropertyChange` for UI updates.
- Updated `SalesView.xaml` to bind the `ListBox`'s `SelectedItem` to the `SelectedProduct` property in `SalesViewModel`. This ensures two-way communication between the view and the view model, allowing UI selections to be reflected in the view model.