### PR TITLE
Enhance cart addition logic in SalesViewModel

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -52,6 +52,7 @@ namespace MRMDesktopUI.ViewModels
             {
                 _selectedProduct = value;
                 NotifyOfPropertyChange(() => SelectedProduct);
+                NotifyOfPropertyChange(() => CanAddToCart);
             }
         }
 
@@ -78,6 +79,7 @@ namespace MRMDesktopUI.ViewModels
             {
                 _itemQuantity = value;
                 NotifyOfPropertyChange(() => ItemQuantity);
+                NotifyOfPropertyChange(() => CanAddToCart);
             }
         }
 
@@ -117,6 +119,10 @@ namespace MRMDesktopUI.ViewModels
 
                 //make sure something is select
                 //make sure item quantity
+                if (ItemQuantity > 0 && SelectedProduct?.QuantityInStock >= ItemQuantity)
+                {
+                    output = true;
+                }
 
                 return output;
             }


### PR DESCRIPTION
This commit updates the SalesViewModel.cs file to improve the logic surrounding the "Add to Cart" functionality. Specifically, the `SelectedProduct` and `ItemQuantity` property setters have been modified to invoke `NotifyOfPropertyChange(() => CanAddToCart)` whenever their values change. This ensures that the `CanAddToCart` property is dynamically re-evaluated to reflect changes in the selected product or its quantity, enabling the UI to update and indicate whether adding to the cart is permissible under the current conditions. Additionally, a new condition has been introduced to the `CanAddToCart` property to check if the `ItemQuantity` is greater than 0 and if the selected product has enough stock (`QuantityInStock`) to fulfill the order. This enhancement ensures that the "Add to Cart" button is only enabled when a valid quantity of a product is selected, and it is in stock, thereby preventing invalid cart additions.