### PR TITLE
Dynamic SubTotal calculation in SalesVM

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -87,8 +87,13 @@ namespace MRMDesktopUI.ViewModels
         {
             get
             {
-                //TODO replace with calculation
-                return "$0.00";
+                decimal subTotal = 0;
+
+                foreach (var item in _cart)
+                {
+                    subTotal += (item.Product.RetailPrice * item.QuantityInCart);
+                }
+                return subTotal.ToString("C");
             }
         }
 
@@ -136,6 +141,7 @@ namespace MRMDesktopUI.ViewModels
                 QuantityInCart = ItemQuantity
             };
             _cart.Add(item);
+            NotifyOfPropertyChange(() => SubTotal);
         }
 
         public bool CanRemoveFromCart
@@ -152,7 +158,7 @@ namespace MRMDesktopUI.ViewModels
 
         public void RemoveFromCart()
         {
-
+            NotifyOfPropertyChange(() => SubTotal);
         }
 
         public bool CanCheckOut


### PR DESCRIPTION
Updated the SalesViewModel to dynamically calculate the `SubTotal` property instead of returning a hardcoded value. This calculation is now performed by iterating over the items in the `_cart` collection, multiplying each item's `RetailPrice` by its `QuantityInCart`, and summing these amounts. The `SubTotal` is then formatted as a currency string.

Additionally, the `NotifyOfPropertyChange` method is called with the `SubTotal` property as its argument after adding or removing items from the cart. This ensures that UI elements bound to the `SubTotal` property are updated to reflect the current subtotal.