### PR TITLE
Refactor SalesViewModel for cart updates

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -70,7 +70,7 @@ namespace MRMDesktopUI.ViewModels
         }
 
 
-        private int _itemQuantity;
+        private int _itemQuantity = 1;
 
         public int ItemQuantity
         {
@@ -122,8 +122,6 @@ namespace MRMDesktopUI.ViewModels
             {
                 bool output = false;
 
-                //make sure something is select
-                //make sure item quantity
                 if (ItemQuantity > 0 && SelectedProduct?.QuantityInStock >= ItemQuantity)
                 {
                     output = true;
@@ -135,12 +133,27 @@ namespace MRMDesktopUI.ViewModels
 
         public void AddToCart()
         {
-            CartItemModel item = new CartItemModel
+            CartItemModel existingItem = Cart.FirstOrDefault(x => x.Product == SelectedProduct);
+
+            if (existingItem != null)
             {
-                Product = SelectedProduct,
-                QuantityInCart = ItemQuantity
-            };
-            _cart.Add(item);
+                existingItem.QuantityInCart += ItemQuantity;
+                // Hack should be better solution for this (refreshing cart display)
+                Cart.Remove(existingItem);
+                Cart.Add(existingItem);
+            }
+            else
+            {
+                CartItemModel item = new CartItemModel
+                {
+                    Product = SelectedProduct,
+                    QuantityInCart = ItemQuantity
+                };
+                _cart.Add(item);
+            }
+
+            SelectedProduct.QuantityInStock -= ItemQuantity;
+            ItemQuantity = 1;
             NotifyOfPropertyChange(() => SubTotal);
         }
 


### PR DESCRIPTION
- Initialized `_itemQuantity` in `SalesViewModel.cs` to 1 by default, ensuring a more intuitive start value for item quantities in the cart.
- Simplified the logic in a getter method to enhance readability and maintainability by removing commented-out code and focusing directly on the essential conditions for enabling cart actions.
- Refactored the `AddToCart` method to support updating item quantities in the cart for existing products, improving the cart's functionality. This includes checking if the selected product is already in the cart and updating its quantity accordingly, refreshing the cart display, and adjusting the product's stock quantity after addition. Additionally, `ItemQuantity` is reset to 1 after adding a product to the cart, ensuring a consistent starting point for new additions.