### PR TITLE
Add IsTaxable to products across DB and app

### DIFF
--- a/MRMData/dbo/Stored Procedures/spProduct_GetAll.sql
+++ b/MRMData/dbo/Stored Procedures/spProduct_GetAll.sql
@@ -3,7 +3,7 @@ AS
 begin
 	set nocount on;
 
-	select Id, ProductName, [Description], RetailPrice, QuantityInStock
+	select Id, ProductName, [Description], RetailPrice, QuantityInStock, IsTaxable
 	from dbo.Product
 	order by ProductName;
 end

--- a/MRMData/dbo/Tables/Product.sql
+++ b/MRMData/dbo/Tables/Product.sql
@@ -6,5 +6,6 @@
     [RetailPrice] MONEY NOT NULL,
     [QuantityInStock] INT NOT NULL DEFAULT 1,
     [CreateDate] DATETIME2 NOT NULL DEFAULT getutcdate(), 
-    [LastModified] DATETIME2 NOT NULL DEFAULT getutcdate()
+    [LastModified] DATETIME2 NOT NULL DEFAULT getutcdate(),
+    [IsTaxable] BIT NOT NULL DEFAULT 1
 )

--- a/MRMDataManager.Library/Models/ProductModel.cs
+++ b/MRMDataManager.Library/Models/ProductModel.cs
@@ -13,5 +13,6 @@ namespace MRMDataManager.Library.Models
         public string Description { get; set; }
         public decimal RetailPrice { get; set; }
         public int QuantityInStock { get; set; }
+        public bool IsTaxable { get; set; }
     }
 }


### PR DESCRIPTION
Updated the `spProduct_GetAll` stored procedure to include the `IsTaxable` column, ensuring the taxable status of products is now retrievable. Modified the `Product` table schema to add a `IsTaxable` BIT column with a default value, reflecting whether products are taxable. Enhanced the `ProductModel` class in the application to include a new `IsTaxable` boolean property, aligning the model with the updated database schema for consistent data representation and manipulation.