### PR TITLE
Add tax rate configuration and usage

### DIFF
--- a/MRMDesktopUI.Library/Helpers/ConfigHelper.cs
+++ b/MRMDesktopUI.Library/Helpers/ConfigHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MRMDesktopUI.Library.Helpers
+{
+    public class ConfigHelper : IConfigHelper
+    {
+        public decimal GetTaxRate()
+        {
+            string rateText = ConfigurationManager.AppSettings["taxRate"];
+
+            bool isValidTaxRate = Decimal.TryParse(rateText, out decimal output);
+
+            if (isValidTaxRate == false)
+            {
+                throw new ConfigurationErrorsException("Tax rate is not working correctly");
+            }
+
+            return output;
+        }
+    }
+}

--- a/MRMDesktopUI.Library/Helpers/IConfigHelper.cs
+++ b/MRMDesktopUI.Library/Helpers/IConfigHelper.cs
@@ -1,0 +1,7 @@
+﻿namespace MRMDesktopUI.Library.Helpers
+{
+    public interface IConfigHelper
+    {
+        decimal GetTaxRate();
+    }
+}

--- a/MRMDesktopUI.Library/MRMDesktopUI.Library.csproj
+++ b/MRMDesktopUI.Library/MRMDesktopUI.Library.csproj
@@ -71,6 +71,8 @@
     <Compile Include="Api\IAPIHelper.cs" />
     <Compile Include="Api\IProductEndpoint.cs" />
     <Compile Include="Api\ProductEndpoint.cs" />
+    <Compile Include="Helpers\ConfigHelper.cs" />
+    <Compile Include="Helpers\IConfigHelper.cs" />
     <Compile Include="Models\AuthenticatedUser.cs" />
     <Compile Include="Models\CartItemModel.cs" />
     <Compile Include="Models\ILoggedInUserModel.cs" />

--- a/MRMDesktopUI.Library/Models/ProductModel.cs
+++ b/MRMDesktopUI.Library/Models/ProductModel.cs
@@ -13,5 +13,6 @@ namespace MRMDesktopUI.Library.Models
         public string Description { get; set; }
         public decimal RetailPrice { get; set; }
         public int QuantityInStock { get; set; }
+        public bool IsTaxable { get; set; }
     }
 }

--- a/MRMDesktopUI/App.config
+++ b/MRMDesktopUI/App.config
@@ -2,16 +2,17 @@
 <configuration>
 	<appSettings>
 		<add key="api" value="https://localhost:44338/" />
+		<add key="taxRate" value="8.75"/>
 	</appSettings>
 	<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
 	</startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
 </configuration>

--- a/MRMDesktopUI/Bootstrapper.cs
+++ b/MRMDesktopUI/Bootstrapper.cs
@@ -1,6 +1,7 @@
 ﻿using Caliburn.Micro;
 using MRMDesktopUI.Helpers;
 using MRMDesktopUI.Library.Api;
+using MRMDesktopUI.Library.Helpers;
 using MRMDesktopUI.Library.Models;
 using MRMDesktopUI.ViewModels;
 using System;
@@ -35,6 +36,7 @@ namespace MRMDesktopUI
                 .Singleton<IWindowManager, WindowManager>()
                 .Singleton<IEventAggregator, EventAggregator>()
                 .Singleton<ILoggedInUserModel, LoggedInUserModel>()
+                .Singleton<IConfigHelper, ConfigHelper>()
                 .Singleton<IAPIHelper, APIHelper>();
 
             GetType().Assembly.GetTypes()

--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Caliburn.Micro;
 using MRMDesktopUI.Library.Api;
+using MRMDesktopUI.Library.Helpers;
 using MRMDesktopUI.Library.Models;
 using System;
 using System.Collections.Generic;
@@ -13,10 +14,12 @@ namespace MRMDesktopUI.ViewModels
     public class SalesViewModel : Screen
     {
         IProductEndpoint _productEndpoint;
+        IConfigHelper _configHelper;
 
-        public SalesViewModel(IProductEndpoint productEndpoint)
+        public SalesViewModel(IProductEndpoint productEndpoint, IConfigHelper configHelper)
         {
             _productEndpoint = productEndpoint;
+            _configHelper = configHelper;
         }
 
         protected override async void OnViewLoaded(object view)
@@ -101,8 +104,17 @@ namespace MRMDesktopUI.ViewModels
         {
             get
             {
-                //TODO replace with calculation
-                return "$0.00";
+                decimal taxAmount = 0;
+                decimal taxRate = _configHelper.GetTaxRate();
+
+                foreach (var item in _cart)
+                {
+                    if (item.Product.IsTaxable)
+                    {
+                        taxAmount += (item.Product.RetailPrice * item.QuantityInCart * taxRate);
+                    }
+                }
+                return taxAmount.ToString("C");
             }
         }
 


### PR DESCRIPTION
- Introduced `ConfigHelper` and `IConfigHelper` in the `Helpers` directory for accessing application configuration settings, specifically to retrieve the tax rate.
- Updated `MRMDesktopUI.Library.csproj` to include the new `ConfigHelper.cs` and `IConfigHelper.cs`.
- Modified `App.config` to add a `taxRate` setting (8.75) and updated `Newtonsoft.Json` assembly binding redirection.
- Updated `Bootstrapper.cs` to register `IConfigHelper` as a singleton service for application-wide access to configuration values.
- Enhanced `SalesViewModel.cs` to inject `IConfigHelper` for tax rate access, modifying the constructor and implementing tax calculation in the `Total` property.
- Added `IsTaxable` property to `ProductModel` to indicate tax eligibility, supporting tax calculations in `SalesViewModel`.