### PR TITLE
Refactor ShellViewModel dependency handling

### DIFF
--- a/MRMDesktopUI/ViewModels/ShellViewModel.cs
+++ b/MRMDesktopUI/ViewModels/ShellViewModel.cs
@@ -13,16 +13,14 @@ namespace MRMDesktopUI.ViewModels
     {
         private IEventAggregator _events;
         private SalesViewModel _salesVM;
-        private SimpleContainer _container;
-        public ShellViewModel(IEventAggregator events, SalesViewModel salesVM, SimpleContainer container)
+        public ShellViewModel(IEventAggregator events, SalesViewModel salesVM)
         {
             _events = events;
             _salesVM = salesVM;
-            _container = container;
 
             _events.Subscribe(this);
 
-            ActivateItem(_container.GetInstance<LoginViewModel>());
+            ActivateItem(IoC.Get<LoginViewModel>());
         }
 
         public void Handle(LogOnEvent message)


### PR DESCRIPTION
- Removed `SimpleContainer` parameter from `ShellViewModel` constructor to simplify dependency management.
- Eliminated `_container` field in `ShellViewModel`, aligning with the constructor change and moving away from specific container dependency.
- Updated `LoginViewModel` activation to use `IoC.Get<LoginViewModel>()` instead of `_container.GetInstance<LoginViewModel>()`, adopting a more generic approach for instance retrieval.