### PR TITLE
Refactor CalculateTax to use LINQ

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -111,13 +111,17 @@ namespace MRMDesktopUI.ViewModels
             decimal taxAmount = 0;
             decimal taxRate = _configHelper.GetTaxRate() / 100;
 
-            foreach (var item in _cart)
-            {
-                if (item.Product.IsTaxable)
-                {
-                    taxAmount += (item.Product.RetailPrice * item.QuantityInCart * taxRate);
-                }
-            }
+            taxAmount = Cart
+                .Where(x => x.Product.IsTaxable)
+                .Sum(x => x.Product.RetailPrice * x.QuantityInCart * taxRate);
+
+            //foreach (var item in _cart)
+            //{
+            //    if (item.Product.IsTaxable)
+            //    {
+            //        taxAmount += (item.Product.RetailPrice * item.QuantityInCart * taxRate);
+            //    }
+            //}
 
             return taxAmount;
         }


### PR DESCRIPTION
Refactored the CalculateTax method in SalesViewModel.cs to enhance readability and efficiency by replacing the original foreach loop with a LINQ expression. The LINQ approach filters the Cart collection for taxable products and calculates the total tax amount using .Where() and .Sum(). The original loop code has been commented out for reference or potential rollback.