### PR TITLE
Add empty classes to MRM libraries

### DIFF
--- a/MRMDataManager.Library/ConfigHelper.cs
+++ b/MRMDataManager.Library/ConfigHelper.cs
@@ -1,0 +1,7 @@
+﻿namespace MRMDataManager.Library
+{
+    public class ConfigHelper
+    {
+        
+    }
+}

--- a/MRMDesktopUI.Library/Models/SaleDetailModel.cs
+++ b/MRMDesktopUI.Library/Models/SaleDetailModel.cs
@@ -1,0 +1,7 @@
+﻿namespace MRMDesktopUI.Library.Models
+{
+    public class SaleDetailModel
+    {
+        
+    }
+}

--- a/MRMDesktopUI.Library/Models/SaleModel.cs
+++ b/MRMDesktopUI.Library/Models/SaleModel.cs
@@ -1,0 +1,7 @@
+﻿namespace MRMDesktopUI.Library.Models
+{
+    public class SaleModel
+    {
+        
+    }
+}


### PR DESCRIPTION
Added three new classes across two namespaces within the MRM project. Specifically, a `ConfigHelper` class in `MRMDataManager.Library`, and both `SaleDetailModel` and `SaleModel` classes in `MRMDesktopUI.Library.Models`. All three classes are currently empty, without any members.