### PR TITLE
Added AutoMapper support and minor config tweak

### DIFF
--- a/MRMDesktopUI/App.config
+++ b/MRMDesktopUI/App.config
@@ -2,7 +2,7 @@
 <configuration>
 	<appSettings>
 		<add key="api" value="https://localhost:44338/" />
-		<add key="taxRate" value="8,75"/>
+		<add key="taxRate" value="8,75" />
 	</appSettings>
 	<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />

--- a/MRMDesktopUI/Bootstrapper.cs
+++ b/MRMDesktopUI/Bootstrapper.cs
@@ -1,8 +1,10 @@
-﻿using Caliburn.Micro;
+﻿using AutoMapper;
+using Caliburn.Micro;
 using MRMDesktopUI.Helpers;
 using MRMDesktopUI.Library.Api;
 using MRMDesktopUI.Library.Helpers;
 using MRMDesktopUI.Library.Models;
+using MRMDesktopUI.Models;
 using MRMDesktopUI.ViewModels;
 using System;
 using System.Collections.Generic;
@@ -29,6 +31,12 @@ namespace MRMDesktopUI
 
         protected override void Configure()
         {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<ProductModel, ProductDisplayModel>();
+                cfg.CreateMap<CartItemModel, CartItemDisplayModel>();
+            });
+
             _container.Instance(_container)
                 .PerRequest<IProductEndpoint, ProductEndpoint>()
                 .PerRequest<ISaleEndPoint, SaleEndPoint>();

--- a/MRMDesktopUI/MRMDesktopUI.csproj
+++ b/MRMDesktopUI/MRMDesktopUI.csproj
@@ -50,6 +50,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoMapper, Version=8.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.8.1.1\lib\net461\AutoMapper.dll</HintPath>
+    </Reference>
     <Reference Include="Caliburn.Micro, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.Core.3.2.0\lib\net45\Caliburn.Micro.dll</HintPath>
     </Reference>

--- a/MRMDesktopUI/packages.config
+++ b/MRMDesktopUI/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoMapper" version="8.1.1" targetFramework="net472" />
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net472" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.Client" version="6.0.0" targetFramework="net472" />


### PR DESCRIPTION
- Updated App.config to ensure consistency in `taxRate` key formatting.
- Incorporated AutoMapper in Bootstrapper.cs, including namespace addition and configuration setup for mapping between `ProductModel` and `ProductDisplayModel`.
- Added AutoMapper reference (v8.1.1.0) to MRMDesktopUI.csproj for project compatibility.
- Included AutoMapper package (v8.1.1) in packages.config, targeting .NET Framework 4.7.2, to facilitate AutoMapper integration.