### PR TITLE
Fix PropertyChanged invocation and cart update logic

### DIFF
--- a/MRMDesktopUI/Models/CartItemDisplayModel.cs
+++ b/MRMDesktopUI/Models/CartItemDisplayModel.cs
@@ -35,7 +35,7 @@ namespace MRMDesktopUI.Models
         public event PropertyChangedEventHandler PropertyChanged;
         public void CallPropertyChanged(string propertyName)
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(propertyName)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/MRMDesktopUI/Models/ProductDisplayModel.cs
+++ b/MRMDesktopUI/Models/ProductDisplayModel.cs
@@ -30,7 +30,7 @@ namespace MRMDesktopUI.Models
         public event PropertyChangedEventHandler PropertyChanged;
         public void CallPropertyChanged(string propertyName)
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(propertyName)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -167,9 +167,6 @@ namespace MRMDesktopUI.ViewModels
             if (existingItem != null)
             {
                 existingItem.QuantityInCart += ItemQuantity;
-                // Hack should be better solution for this (refreshing cart display)
-                Cart.Remove(existingItem);
-                Cart.Add(existingItem);
             }
             else
             {


### PR DESCRIPTION
- Corrected the invocation of the PropertyChanged event in both CartItemDisplayModel.cs and ProductDisplayModel.cs. The previous implementation incorrectly used nameof(propertyName), which has been updated to correctly pass the actual property name using new PropertyChangedEventArgs(propertyName).

- Refactored the cart update logic in SalesViewModel.cs to streamline the process of updating the cart when the quantity of an existing item is increased. The previous method of removing and then re-adding the item to the Cart collection has been replaced with a more efficient approach, improving the UI update mechanism.