### PR TITLE
Refactor Bootstrapper and update models

### DIFF
--- a/MRMDesktopUI.Library/Models/CartItemModel.cs
+++ b/MRMDesktopUI.Library/Models/CartItemModel.cs
@@ -10,13 +10,5 @@ namespace MRMDesktopUI.Library.Models
     {
         public ProductModel Product { get; set; }
         public int QuantityInCart { get; set; }
-        public string DisplayText
-        {
-            get
-            {
-                return $"{Product.ProductName} ({QuantityInCart})";
-            }
-
-        }
     }
 }

--- a/MRMDesktopUI/Bootstrapper.cs
+++ b/MRMDesktopUI/Bootstrapper.cs
@@ -29,7 +29,7 @@ namespace MRMDesktopUI
             "PasswordChanged");
         }
 
-        protected override void Configure()
+        private IMapper ConfigureAutomapper()
         {
             var config = new MapperConfiguration(cfg =>
             {
@@ -37,9 +37,15 @@ namespace MRMDesktopUI
                 cfg.CreateMap<CartItemModel, CartItemDisplayModel>();
             });
 
-            var mapper = config.CreateMapper();
+            var output = config.CreateMapper();
 
-            _container.Instance(mapper);
+            return output;
+        }
+
+        protected override void Configure()
+        {
+
+            _container.Instance(ConfigureAutomapper());
 
             _container.Instance(_container)
                 .PerRequest<IProductEndpoint, ProductEndpoint>()


### PR DESCRIPTION
- Removed `DisplayText` property from `CartItemModel` in `MRMDesktopUI.Library.Models`. This property combined `ProductName` and `QuantityInCart` into a single string, which is no longer needed.
- Refactored `Configure` method in `Bootstrapper.cs` of `MRMDesktopUI`. Changed its visibility to private and renamed it to `ConfigureAutomapper`. This method now exclusively configures AutoMapper, setting up mappings between `ProductModel` and `ProductDisplayModel`, as well as `CartItemModel` and `CartItemDisplayModel`.
- Introduced a new `ConfigureAutomapper` method to create and configure an AutoMapper `IMapper` instance, which is then registered with the dependency injection container.
- Restored the original `Configure` method as `protected override`, simplifying it to call `ConfigureAutomapper` for `IMapper` instance registration and continuing to configure other services like `IProductEndpoint` and `ISaleEndPoint`.
- This update enhances code modularity and clarity by separating AutoMapper configuration from other setup tasks.