### PR TITLE
Update cart item addition logic in ViewModel

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -206,7 +206,7 @@ namespace MRMDesktopUI.ViewModels
                 bool output = false;
 
                 //make sure something is select
-                if (SelectedCartItem != null && SelectedCartItem?.Product.QuantityInStock > 0)
+                if (SelectedCartItem != null && SelectedCartItem?.QuantityInCart > 0)
                 {
                     output = true;
                 }
@@ -232,6 +232,7 @@ namespace MRMDesktopUI.ViewModels
             NotifyOfPropertyChange(() => Tax);
             NotifyOfPropertyChange(() => Total);
             NotifyOfPropertyChange(() => CanCheckOut);
+            NotifyOfPropertyChange(() => CanAddToCart);
         }
 
         public bool CanCheckOut


### PR DESCRIPTION
- Modified the condition for enabling item addition to the cart in `SalesViewModel.cs`. The logic now checks if `SelectedCartItem` is not null and if `QuantityInCart` is greater than 0, shifting focus from stock availability to cart quantity.
- Added a new line to notify changes in the `CanAddToCart` property, enhancing dynamic UI responsiveness to cart item addition conditions.