### PR TITLE
Add async ResetSalesViewModel method

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -67,6 +67,13 @@ namespace MRMDesktopUI.ViewModels
             }
         }
 
+        private async Task ResetSalesViewModel()
+        {
+            Cart = new BindingList<CartItemDisplayModel>();
+            //TODO add clearing the selected cartitem if it does not do it itself
+            await LoadProducts();
+        }
+
         private CartItemDisplayModel _selectedCartItem;
 
         public CartItemDisplayModel SelectedCartItem
@@ -266,6 +273,8 @@ namespace MRMDesktopUI.ViewModels
             }
 
             await _saleEndPoint.PostSale(sale);
+
+            await ResetSalesViewModel();
         }
     }
 }


### PR DESCRIPTION
- Implemented a new asynchronous method `ResetSalesViewModel` in the `SalesViewModel` class to reinitialize the `Cart` property with a fresh `BindingList<CartItemDisplayModel>` and reload the product list by calling `LoadProducts` asynchronously.
- Added a comment within `ResetSalesViewModel` suggesting a potential improvement for future consideration: clearing the selected cart item if not done automatically.
- The `ResetSalesViewModel` method is invoked asynchronously following a sale completion via `_saleEndPoint.PostSale(sale)` to ensure the sales view model is reset for new transactions.