### PR TITLE
Update ResetSalesViewModel for UI refresh

### DIFF
--- a/MRMDesktopUI/ViewModels/SalesViewModel.cs
+++ b/MRMDesktopUI/ViewModels/SalesViewModel.cs
@@ -72,6 +72,11 @@ namespace MRMDesktopUI.ViewModels
             Cart = new BindingList<CartItemDisplayModel>();
             //TODO add clearing the selected cartitem if it does not do it itself
             await LoadProducts();
+
+            NotifyOfPropertyChange(() => SubTotal);
+            NotifyOfPropertyChange(() => Tax);
+            NotifyOfPropertyChange(() => Total);
+            NotifyOfPropertyChange(() => CanCheckOut);
         }
 
         private CartItemDisplayModel _selectedCartItem;


### PR DESCRIPTION
Updated the ResetSalesViewModel method in the SalesViewModel class to call NotifyOfPropertyChange for `SubTotal`, `Tax`, `Total`, and `CanCheckOut` properties. This ensures the UI correctly reflects the updated state of these properties after resetting the sales view model.