### PR TITLE
Refactor user log-off process

### DIFF
--- a/MRMDesktopUI.Library/Api/APIHelper.cs
+++ b/MRMDesktopUI.Library/Api/APIHelper.cs
@@ -63,6 +63,11 @@ namespace MRMDesktopUI.Library.Api
             }
         }
 
+        public void LogOffUser()
+        {
+            _apiClient.DefaultRequestHeaders.Clear();
+        }
+
         public async Task GetLoggedInUserInfo(string token)
         {
             _apiClient.DefaultRequestHeaders.Clear();

--- a/MRMDesktopUI.Library/Api/IAPIHelper.cs
+++ b/MRMDesktopUI.Library/Api/IAPIHelper.cs
@@ -8,6 +8,7 @@ namespace MRMDesktopUI.Library.Api
     {
         HttpClient ApiClient { get; }
         Task<AuthenticatedUser> Authenticate(string username, string password);
+        void LogOffUser();
         Task GetLoggedInUserInfo(string token);
     }
 }

--- a/MRMDesktopUI.Library/Models/ILoggedInUserModel.cs
+++ b/MRMDesktopUI.Library/Models/ILoggedInUserModel.cs
@@ -11,6 +11,6 @@ namespace MRMDesktopUI.Library.Models
         string LastName { get; set; }
         string Token { get; set; }
 
-        void LogOffUser();
+        void ResetUserModel();
     }
 }

--- a/MRMDesktopUI.Library/Models/LoggedInUserModel.cs
+++ b/MRMDesktopUI.Library/Models/LoggedInUserModel.cs
@@ -15,7 +15,7 @@ namespace MRMDesktopUI.Library.Models
         public string EmailAddress { get; set; }
         public DateTime CreatedDate { get; set; }
 
-        public void LogOffUser()
+        public void ResetUserModel()
         {
             Token = "";
             Id = "";

--- a/MRMDesktopUI/ViewModels/ShellViewModel.cs
+++ b/MRMDesktopUI/ViewModels/ShellViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Caliburn.Micro;
 using MRMDesktopUI.EventModels;
+using MRMDesktopUI.Library.Api;
 using MRMDesktopUI.Library.Models;
 using System;
 using System.Collections.Generic;
@@ -15,12 +16,15 @@ namespace MRMDesktopUI.ViewModels
         private IEventAggregator _events;
         private SalesViewModel _salesVM;
         private ILoggedInUserModel _user;
+        private IAPIHelper _apiHelper;
 
-        public ShellViewModel(IEventAggregator events, SalesViewModel salesVM, ILoggedInUserModel user)
+        public ShellViewModel(IEventAggregator events, SalesViewModel salesVM, ILoggedInUserModel user, IAPIHelper apiHelper)
         {
             _events = events;
             _salesVM = salesVM;
             _user = user;
+            _apiHelper = apiHelper;
+
             _events.Subscribe(this);
 
             ActivateItem(IoC.Get<LoginViewModel>());
@@ -48,7 +52,8 @@ namespace MRMDesktopUI.ViewModels
 
         public void LogOut()
         {
-            _user.LogOffUser();
+            _user.ResetUserModel();
+            _apiHelper.LogOffUser();
             ActivateItem(IoC.Get<LoginViewModel>());
             NotifyOfPropertyChange(() => IsLoggedIn);
         }


### PR DESCRIPTION
This commit introduces several key changes aimed at improving the user log-off process across the application. In the APIHelper.cs file, a new method `LogOffUser` has been added to clear the default request headers in the `_apiClient`, ensuring a clean state for subsequent requests. The `GetLoggedInUserInfo` method has been updated to clear headers at the start, preventing potential carry-over of state.

The `IAPIHelper` interface now includes the `LogOffUser` method declaration, enforcing its implementation in classes that utilize this interface. This change aligns with the removal of the `LogOffUser` method from the `ILoggedInUserModel` interface, where it has been replaced by `ResetUserModel`. This new method resets user model properties to their default states, facilitating a clear separation of concerns between the API and user model management upon logging off.

In the `LoggedInUserModel.cs` file, the `ResetUserModel` method has been implemented to clear user information, replacing the previous `LogOffUser` method. This ensures that user data is appropriately reset.

The `ShellViewModel.cs` file sees the addition of the `IAPIHelper` interface to its using directives, allowing for the use of API helper methods within the class. The constructor now accepts an `IAPIHelper` parameter, and a private `_apiHelper` field has been added for API interaction. The `LogOut` method has been modified to call `_user.ResetUserModel()` and `_apiHelper.LogOffUser()`, ensuring both the user model and API client are reset during log-off.

These changes collectively enhance the application's handling of user log-offs, ensuring a clean separation of concerns and a more robust clearing of user and application state.