### PR TITLE
Improve database connection management

### DIFF
--- a/MRMDataManager.Library/Internal/DataAccess/SqlDataAccess.cs
+++ b/MRMDataManager.Library/Internal/DataAccess/SqlDataAccess.cs
@@ -52,6 +52,8 @@ namespace MRMDataManager.Library.Internal.DataAccess
             _connection.Open();
 
             _transaction = _connection.BeginTransaction();
+
+            IsClosed = false;
         }
 
         public List<T> LoadDataInTransaction<T, U>(string storedProcedure, U parameters)
@@ -68,21 +70,40 @@ namespace MRMDataManager.Library.Internal.DataAccess
                commandType: CommandType.StoredProcedure, transaction: _transaction);
         }
 
+        private bool IsClosed = false;
+
         public void CommitTransaction()
         {
             _transaction?.Commit();
             _connection?.Close();
+
+            IsClosed = true;
         }
 
         public void RollBackTransaction()
         {
             _transaction?.Rollback();
             _connection?.Close();
+
+            IsClosed = true;
         }
 
         public void Dispose()
         {
-            CommitTransaction();
+            if (IsClosed == false)
+            {
+                try
+                {
+                    CommitTransaction();
+                }
+                catch
+                {
+                    // TODO - log this issue
+                }
+            }
+
+            _transaction = null;
+            _connection = null;
         }
 
         // Open connection/start transaction method


### PR DESCRIPTION
Added a private `IsClosed` field to track the database connection state, ensuring it's only closed once. Modified the `Dispose` method to check this field before attempting to commit, preventing errors on already closed connections. This update enhances the reliability of connection and transaction handling by avoiding attempts to commit on closed connections and adding error handling for commit operations.