### PR TITLE
Add SaleReport functionality and cleanup

### DIFF
--- a/MRMDataManager.Library/DataAccess/SaleData.cs
+++ b/MRMDataManager.Library/DataAccess/SaleData.cs
@@ -84,14 +84,13 @@ namespace MRMDataManager.Library.DataAccess
             }
         }
 
+        public List<SaleReportModel> GetSaleReport()
+        {
+            SqlDataAccess sql = new SqlDataAccess();
 
-        //public List<ProductModel> GetProducts()
-        //{
-        //    SqlDataAccess sql = new SqlDataAccess();
+            var output = sql.LoadData<SaleReportModel, dynamic>("dbo.spSale_SaleReport", new { }, "MRMData");
 
-        //    var output = sql.LoadData<ProductModel, dynamic>("dbo.spProduct_GetAll", new { }, "MRMData");
-
-        //    return output;
-        //}
+            return output;
+        }
     }
 }

--- a/MRMDataManager.Library/MRMDataManager.Library.csproj
+++ b/MRMDataManager.Library/MRMDataManager.Library.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Models\SaleDetailDBModel.cs" />
     <Compile Include="Models\SaleDetailModel.cs" />
     <Compile Include="Models\SaleModel.cs" />
+    <Compile Include="Models\SaleReportModel.cs" />
     <Compile Include="Models\UserModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Internal\DataAccess\SqlDataAccess.cs" />

--- a/MRMDataManager.Library/Models/SaleReportModel.cs
+++ b/MRMDataManager.Library/Models/SaleReportModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MRMDataManager.Library.Models
+{
+    public class SaleReportModel
+    {
+        public DateTime SaleDate { get; set; }
+        public decimal SubTotal { get; set; }
+        public decimal Tax { get; set; }
+        public decimal Total { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string EmailAddress { get; set; }
+    }
+}


### PR DESCRIPTION
- Implemented `GetSaleReport` method in `SaleData.cs` to fetch sales report data using `dbo.spSale_SaleReport` stored procedure and return a list of `SaleReportModel`.
- Removed unused `GetProducts` method and its comments from `SaleData.cs`.
- Added `SaleReportModel.cs` to define the data structure for sales reports, including sale details and customer information.
- Included `SaleReportModel.cs` in `MRMDataManager.Library.csproj` for compilation.