### PR TITLE
Add SaveInventory and GetSalesReport endpoints

### DIFF
--- a/MRMDataManager.Library/DataAccess/InventoryData.cs
+++ b/MRMDataManager.Library/DataAccess/InventoryData.cs
@@ -18,5 +18,12 @@ namespace MRMDataManager.Library.DataAccess
 
             return output;
         }
+
+        public void SaveInventoryRecord(InventoryModel item)
+        {
+            SqlDataAccess sql = new SqlDataAccess();
+
+            sql.SaveData("dbo.spInventory_Insert", item, "MRMData");
+        }
     }
 }

--- a/MRMDataManager/Controllers/SaleController.cs
+++ b/MRMDataManager/Controllers/SaleController.cs
@@ -20,5 +20,13 @@ namespace MRMDataManager.Controllers
 
             data.SaveSale(sale, userId);
         }
+
+        [Route("GetSalesReport")]
+        public List<SaleReportModel> GetSalesReport()
+        {
+            SaleData data = new SaleData();
+
+            return data.GetSaleReport();
+        }
     }
 }


### PR DESCRIPTION
- Added `SaveInventoryRecord` method in `InventoryData.cs` to save inventory records to the database using `SqlDataAccess` and the `dbo.spInventory_Insert` stored procedure.
- Introduced a new API endpoint `GetSalesReport` in `SaleController.cs` that returns a list of `SaleReportModel` objects by fetching sales report data through the `SaleData`'s `GetSaleReport` method.