### PR TITLE
Add admin user API and update error msg

### DIFF
--- a/MRMDataManager/Controllers/UserController.cs
+++ b/MRMDataManager/Controllers/UserController.cs
@@ -57,5 +57,18 @@ namespace MRMDataManager.Controllers
 
             return output;
         }
+
+        [Authorize(Roles = "Admin")]
+        [HttpGet]
+        [Route("api/User/Admin/GetAllUsers")]
+        public Dictionary<string, string> GetAllRoles()
+        {
+            using (var context = new ApplicationDbContext())
+            {
+                var roles = context.Roles.ToDictionary(x => x.Id, x => x.Name);
+
+                return roles;
+            }
+        }
     }
 }

--- a/MRMDesktopUI/ViewModels/UserDisplayViewModel.cs
+++ b/MRMDesktopUI/ViewModels/UserDisplayViewModel.cs
@@ -57,7 +57,7 @@ namespace MRMDesktopUI.ViewModels
 
                 if (ex.Message == "Unauthorized")
                 {
-                    _status.UpdateMessage("Unauthorized Access", "You don't have permission to interact with the Sales Form.");
+                    _status.UpdateMessage("Unauthorized Access", "You don't have permission to interact with the Users Form.");
                     _window.ShowDialog(_status, null, settings);
                 }
                 else


### PR DESCRIPTION
- Added a new API endpoint in UserController.cs under the MRMDataManager.Controllers namespace. This endpoint, `api/User/Admin/GetAllUsers`, is secured with `[Authorize(Roles = "Admin")]` and returns all user roles from the ApplicationDbContext as a Dictionary mapping role IDs to names. It's a `HttpGet` method named `GetAllRoles` and ensures proper disposal of the ApplicationDbContext using a `using` statement.

- Updated the error message in UserDisplayViewModel.cs within the MRMDesktopUI.ViewModels namespace to accurately reflect unauthorized access to the "Users Form" instead of the "Sales Form". This change improves the clarity of the error message for end-users.