### PR TITLE
Add role management methods to UserEndPoint

### DIFF
--- a/MRMDesktopUI.Library/Api/IUserEndPoint.cs
+++ b/MRMDesktopUI.Library/Api/IUserEndPoint.cs
@@ -6,8 +6,6 @@ namespace MRMDesktopUI.Library.Api
 {
     public interface IUserEndPoint
     {
-        IAPIHelper _apiHelper { get; }
-
         Task<List<UserModel>> GetAll();
     }
 }

--- a/MRMDesktopUI.Library/Api/UserEndPoint.cs
+++ b/MRMDesktopUI.Library/Api/UserEndPoint.cs
@@ -32,5 +32,44 @@ namespace MRMDesktopUI.Library.Api
                 }
             }
         }
+        public async Task<Dictionary<string, string>> GetAllRoles()
+        {
+            using (HttpResponseMessage response = await _apiHelper.ApiClient.GetAsync("api/User/Admin/GetAllRoles"))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var result = await response.Content.ReadAsAsync<Dictionary<string, string>>();
+                    return result;
+                }
+                else
+                {
+                    throw new Exception(response.ReasonPhrase);
+                }
+            }
+        }
+        public async Task AddUserToRole(string userId, string roleName)
+        {
+            var data = new { userId, roleName };
+
+            using (HttpResponseMessage response = await _apiHelper.ApiClient.PostAsJsonAsync("api/User/Admin/AddRole", data))
+            {
+                if (response.IsSuccessStatusCode == false)
+                {
+                    throw new Exception(response.ReasonPhrase);
+                }
+            }
+        }
+        public async Task RemoveUserFromRole(string userId, string roleName)
+        {
+            var data = new { userId, roleName };
+
+            using (HttpResponseMessage response = await _apiHelper.ApiClient.PostAsJsonAsync("api/User/Admin/RemoveRole", data))
+            {
+                if (response.IsSuccessStatusCode == false)
+                {
+                    throw new Exception(response.ReasonPhrase);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Implemented `GetAllRoles` in `UserEndPoint` to fetch roles via `api/User/Admin/GetAllRoles`.
- Added `AddUserToRole` method for assigning roles through `api/User/Admin/AddRole`.
- Created `RemoveUserFromRole` for role removal via `api/User/Admin/RemoveRole`. Each method handles success and failure scenarios, throwing exceptions on failure.